### PR TITLE
feat: add widget inbox

### DIFF
--- a/apps/widget/modules/widget/ui/components/widget-footer.tsx
+++ b/apps/widget/modules/widget/ui/components/widget-footer.tsx
@@ -1,14 +1,18 @@
 import { HomeIcon, InboxIcon } from "lucide-react";
 import { cn } from "@workspace/ui/lib/utils";
 import { Button } from "@workspace/ui/components/button";
+import { useSetAtom } from "jotai";
+import { screenAtom } from "../../atoms/widget";
 
 export const WidgetFooter = () => {
+  const setScreen = useSetAtom(screenAtom);
+
   let screen = "selection";
   return (
     <footer className="flex items-center justify-between border-t bg-background">
       <Button
         className="h-14 flex-1 rounded-none"
-        onClick={() => {}}
+        onClick={() => setScreen("selection")}
         size="icon"
         variant="ghost"
         aria-label="Home"
@@ -21,7 +25,7 @@ export const WidgetFooter = () => {
       </Button>
       <Button
         className="h-14 flex-1 rounded-none"
-        onClick={() => {}}
+        onClick={() => setScreen("inbox")}
         size="icon"
         variant="ghost"
         aria-label="Inbox"

--- a/apps/widget/modules/widget/ui/screens/widget-inbox.tsx
+++ b/apps/widget/modules/widget/ui/screens/widget-inbox.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { WidgetHeader } from "../components/widget-header";
+import { usePaginatedQuery } from "convex/react";
+import { formatDistanceToNow } from "date-fns";
+import { api } from "@workspace/backend/_generated/api";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  contactSessionIdAtomFamily,
+  conversationIdAtom,
+  organizationIdAtom,
+  screenAtom,
+} from "../../atoms/widget";
+import { WidgetFooter } from "../components/widget-footer";
+import { Button } from "@workspace/ui/components/button";
+import { ConversationStatusIcon } from "@workspace/ui/components/conversation-status-icon";
+import { ArrowLeftIcon } from "lucide-react";
+import { useInfiniteScroll } from "@workspace/ui/hooks/useInfiniteScroll";
+import InfiniteScrollTrigger from "@workspace/ui/components/infinite-scroll-trigger";
+
+const WidgetInboxScreen = () => {
+  const setScreen = useSetAtom(screenAtom);
+  const setConversationId = useSetAtom(conversationIdAtom);
+  const organizationId = useAtomValue(organizationIdAtom);
+  const contactSessionId = useAtomValue(
+    contactSessionIdAtomFamily(organizationId || "")
+  );
+
+  const conversations = usePaginatedQuery(
+    api.public.conversations.getMany,
+    contactSessionId
+      ? {
+          contactSessionId,
+        }
+      : "skip",
+    {
+      initialNumItems: 10,
+    }
+  );
+
+  const { topElementRef, isLoadingMore, canLoadMore, handleLoadMore } =
+    useInfiniteScroll({
+      status: conversations.status,
+      loadMore: conversations.loadMore,
+      loadSize: 10,
+    });
+
+  return (
+    <>
+      <WidgetHeader>
+        <div className="flex items-center gap-x-2">
+          <Button
+            size="icon"
+            variant="transparent"
+            onClick={() => setScreen("selection")}
+          >
+            <ArrowLeftIcon />
+          </Button>
+        </div>
+      </WidgetHeader>
+      <div className="flex flex-1 flex-col gap-y-2 p-4 overflow-y-auto">
+        {conversations?.results.length > 0 &&
+          conversations.results.map((conversation) => (
+            <Button
+              className="h-20 w-full justify-between"
+              key={conversation._id}
+              onClick={() => {
+                setConversationId(conversation._id);
+                setScreen("chat");
+              }}
+              variant="outline"
+            >
+              <div className="flex w-full flex-col gap-4 overflow-hidden text-start">
+                <div className="flex w-full items-center justify-between gap-x-2">
+                  <p className="text-muted-foreground text-xs">Chat</p>
+                  <p className="text-muted-foreground text-xs">
+                    {formatDistanceToNow(new Date(conversation._creationTime))}
+                  </p>
+                </div>
+                <div className="flex w-full items-center justify-between gap-x-2">
+                  <p className="truncate text-sm">
+                    {conversation.lastMessage?.text}
+                  </p>
+                  <ConversationStatusIcon status={conversation.status} />
+                </div>
+              </div>
+            </Button>
+          ))}
+        <InfiniteScrollTrigger
+          canLoadMore={canLoadMore}
+          onLoadMore={handleLoadMore}
+          ref={topElementRef}
+          isLoadingMore={isLoadingMore}
+        />
+      </div>
+      <WidgetFooter />
+    </>
+  );
+};
+
+export default WidgetInboxScreen;

--- a/apps/widget/modules/widget/ui/screens/widget-selection.tsx
+++ b/apps/widget/modules/widget/ui/screens/widget-selection.tsx
@@ -14,6 +14,7 @@ import {
 import { useMutation } from "convex/react";
 import { api } from "@workspace/backend/_generated/api";
 import { useState } from "react";
+import { WidgetFooter } from "../components/widget-footer";
 
 export const WidgetSelectionScreen = () => {
   const setScreen = useSetAtom(screenAtom);
@@ -76,6 +77,7 @@ export const WidgetSelectionScreen = () => {
           <ChevronRightIcon />
         </Button>
       </div>
+      <WidgetFooter />
     </>
   );
 };

--- a/apps/widget/modules/widget/ui/views/widget-view.tsx
+++ b/apps/widget/modules/widget/ui/views/widget-view.tsx
@@ -9,6 +9,7 @@ import { WidgetErrorScreen } from "../screens/widget-error";
 import { WidgetLoadingScreen } from "../screens/widget-loading";
 import { WidgetSelectionScreen } from "../screens/widget-selection";
 import { WidgetChatScreen } from "../screens/widget-chat";
+import WidgetInboxScreen from "../screens/widget-inbox";
 
 interface Props {
   organizationId: string;
@@ -23,7 +24,7 @@ export const WidgetView = (props: Props) => {
     loading: <WidgetLoadingScreen organizationId={organizationId} />,
     auth: <WidgetAuthScreen />,
     voice: <p>TODO: Voice</p>,
-    inbox: <p>TODO: Inbox</p>,
+    inbox: <WidgetInboxScreen />,
     selection: <WidgetSelectionScreen />,
     chat: <WidgetChatScreen />,
     contact: <p>TODO: Contact</p>,

--- a/apps/widget/package.json
+++ b/apps/widget/package.json
@@ -18,6 +18,7 @@
     "@workspace/backend": "workspace:*",
     "@workspace/ui": "workspace:*",
     "convex": "1.25.4",
+    "date-fns": "4.1.0",
     "jotai": "2.14.0",
     "lucide-react": "0.475.0",
     "next": "15.4.5",

--- a/packages/backend/convex/public/conversations.ts
+++ b/packages/backend/convex/public/conversations.ts
@@ -3,6 +3,62 @@ import { ConvexError, v } from "convex/values";
 import { supportAgent } from "../system/ai/agents/supportAgent";
 import { saveMessage } from "@convex-dev/agent";
 import { components } from "../_generated/api";
+import { paginationOptsValidator } from "convex/server";
+import { MessageDoc } from "@convex-dev/agent";
+
+export const getMany = query({
+  args: {
+    contactSessionId: v.id("contactSessions"),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const contactSession = await ctx.db.get(args.contactSessionId);
+
+    if (!contactSession || contactSession.expiresAt < Date.now()) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Invalid session",
+      });
+    }
+
+    const conversations = await ctx.db
+      .query("conversations")
+      .withIndex("by_contact_session_id", (q) =>
+        q.eq("contactSessionId", args.contactSessionId)
+      )
+      .order("desc")
+      .paginate(args.paginationOpts);
+
+    const conversationsWithLastMessage = await Promise.all(
+      conversations.page.map(async (conversation) => {
+        let lastMessage: MessageDoc | null = null;
+
+        const messages = await supportAgent.listMessages(ctx, {
+          threadId: conversation.threadId,
+          paginationOpts: { numItems: 1, cursor: null },
+        });
+
+        if (messages.page.length > 0) {
+          lastMessage = messages.page[0] ?? null;
+        }
+
+        return {
+          _id: conversation._id,
+          _creationTime: conversation._creationTime,
+          status: conversation.status,
+          organizationId: conversation.organizationId,
+          threadId: conversation.threadId,
+          lastMessage,
+        };
+      })
+    );
+
+    return {
+      ...conversations,
+      page: conversationsWithLastMessage,
+    };
+  },
+});
 
 export const getOne = query({
   args: {

--- a/packages/ui/src/components/conversation-status-icon.tsx
+++ b/packages/ui/src/components/conversation-status-icon.tsx
@@ -1,0 +1,39 @@
+import { ArrowRightIcon, ArrowUpIcon, CheckIcon } from "lucide-react";
+import { cn } from "@workspace/ui/lib/utils";
+
+interface ConversationStatusIconProps {
+  status: "unresolved" | "escalated" | "resolved";
+}
+
+const statusConfig = {
+  resolved: {
+    icon: CheckIcon,
+    bgColor: "bg-[#3FB62F]",
+  },
+  unresolved: {
+    icon: ArrowRightIcon,
+    bgColor: "bg-destructive",
+  },
+  escalated: {
+    icon: ArrowUpIcon,
+    bgColor: "bg-yellow-500",
+  },
+};
+
+const ConversationStatusIcon = ({ status }: ConversationStatusIconProps) => {
+  const config = statusConfig[status];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-full p-1.5",
+        config.bgColor
+      )}
+    >
+      <Icon className="size-3 stroke-3 text-white" />
+    </div>
+  );
+};
+
+export { ConversationStatusIcon };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       convex:
         specifier: 1.25.4
         version: 1.25.4(@clerk/clerk-react@5.47.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      date-fns:
+        specifier: 4.1.0
+        version: 4.1.0
       jotai:
         specifier: 2.14.0
         version: 2.14.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.9)(react@19.1.1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an Inbox screen to browse conversations with last message previews, relative timestamps, status indicators, and infinite scrolling. Tap a conversation to open chat; back navigation supported.
  - Footer buttons now switch between Home and Inbox for quicker navigation.
  - New conversation status icon for consistent visual cues.
  - Backend support for paginated conversation lists including last message data.
- Chores
  - Added a date utility library for time formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->